### PR TITLE
Updated timm imports

### DIFF
--- a/MNIST_VAE.ipynb
+++ b/MNIST_VAE.ipynb
@@ -1,0 +1,265 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "authorship_tag": "ABX9TyN7EUPcnax86HEhaVzfv6H5",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/y-arjun-y/EfficientFormer/blob/main/MNIST_VAE.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "from torch import nn\n",
+        "\n",
+        "\n",
+        "class VariationalAutoEncoder(nn.Module):\n",
+        "    def __init__(self, input_dim, h_dim=200, z_dim=20):\n",
+        "        super().__init__()\n",
+        "        # encoder\n",
+        "        self.img_2hid = nn.Linear(input_dim, h_dim)\n",
+        "        self.hid_2mu = nn.Linear(h_dim, z_dim)\n",
+        "        self.hid_2sigma = nn.Linear(h_dim, z_dim)\n",
+        "\n",
+        "        # decoder\n",
+        "        self.z_2hid = nn.Linear(z_dim, h_dim)\n",
+        "        self.hid_2img = nn.Linear(h_dim, input_dim)\n",
+        "\n",
+        "        self.relu = nn.ReLU()\n",
+        "\n",
+        "    def encode(self, x):\n",
+        "        h = self.relu(self.img_2hid(x))\n",
+        "        mu, sigma = self.hid_2mu(h), self.hid_2sigma(h)\n",
+        "        return mu, sigma\n",
+        "\n",
+        "    def decode(self, z):\n",
+        "        h = self.relu(self.z_2hid(z))\n",
+        "        return torch.sigmoid(self.hid_2img(h))\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        mu, sigma = self.encode(x)\n",
+        "        epsilon = torch.randn_like(sigma)\n",
+        "        z_new = mu + sigma*epsilon\n",
+        "        x_reconstructed = self.decode(z_new)\n",
+        "        return x_reconstructed, mu, sigma\n",
+        "\n",
+        "\n",
+        "if __name__ == \"__main__\":\n",
+        "    x = torch.randn(4, 28*28)\n",
+        "    vae = VariationalAutoEncoder(input_dim=784)\n",
+        "    x_reconstructed, mu, sigma = vae(x)\n",
+        "    print(x_reconstructed.shape)\n",
+        "    print(mu.shape)\n",
+        "    print(sigma.shape)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "aUrAwRsuczhT",
+        "outputId": "a7bb51b2-7966-4617-dec5-98c3d0c3a91e"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "torch.Size([4, 784])\n",
+            "torch.Size([4, 20])\n",
+            "torch.Size([4, 20])\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "import torchvision.datasets as datasets  # Standard datasets\n",
+        "from tqdm import tqdm\n",
+        "from torch import nn, optim\n",
+        "from torchvision import transforms\n",
+        "from torchvision.utils import save_image\n",
+        "from torch.utils.data import DataLoader\n",
+        "\n",
+        "# Configuration\n",
+        "DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+        "INPUT_DIM = 784\n",
+        "H_DIM = 200\n",
+        "Z_DIM = 20\n",
+        "NUM_EPOCHS = 50\n",
+        "BATCH_SIZE = 32\n",
+        "LR_RATE = 3e-4  # Karpathy constant\n",
+        "\n",
+        "# Dataset Loading\n",
+        "dataset = datasets.MNIST(root=\"dataset/\", train=True, transform=transforms.ToTensor(), download=True)\n",
+        "train_loader = DataLoader(dataset=dataset, batch_size=BATCH_SIZE, shuffle=True)\n",
+        "model = VariationalAutoEncoder(INPUT_DIM, H_DIM, Z_DIM).to(DEVICE)\n",
+        "optimizer = optim.Adam(model.parameters(), lr=LR_RATE)\n",
+        "loss_fn = nn.BCELoss(reduction=\"sum\")\n",
+        "\n",
+        "\n",
+        "def inference(digit, num_examples=1):\n",
+        "    \"\"\"\n",
+        "    Generates (num_examples) of a particular digit.\n",
+        "    Specifically we extract an example of each digit,\n",
+        "    then after we have the mu, sigma representation for\n",
+        "    each digit we can sample from that.\n",
+        "\n",
+        "    After we sample we can run the decoder part of the VAE\n",
+        "    and generate examples.\n",
+        "    \"\"\"\n",
+        "    images = []\n",
+        "    idx = 0\n",
+        "    for x, y in dataset:\n",
+        "        if y == idx:\n",
+        "            images.append(x)\n",
+        "            idx += 1\n",
+        "        if idx == 10:\n",
+        "            break\n",
+        "\n",
+        "    encodings_digit = []\n",
+        "    for d in range(10):\n",
+        "        with torch.no_grad():\n",
+        "            mu, sigma = model.encode(images[d].view(1, 784))\n",
+        "        encodings_digit.append((mu, sigma))\n",
+        "\n",
+        "    mu, sigma = encodings_digit[digit]\n",
+        "    for example in range(num_examples):\n",
+        "        epsilon = torch.randn_like(sigma)\n",
+        "        z = mu + sigma * epsilon\n",
+        "        out = model.decode(z)\n",
+        "        out = out.view(-1, 1, 28, 28)\n",
+        "        save_image(out, f\"generated_{digit}_ex{example}.png\")\n",
+        "\n",
+        "for idx in range(10):\n",
+        "    inference(idx, num_examples=100)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "11Vv5N75g1ND",
+        "outputId": "3f169817-a6d4-473a-8b27-73be0ebc7af2"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to dataset/MNIST/raw/train-images-idx3-ubyte.gz\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 9912422/9912422 [00:00<00:00, 128956920.73it/s]\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Extracting dataset/MNIST/raw/train-images-idx3-ubyte.gz to dataset/MNIST/raw\n",
+            "\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to dataset/MNIST/raw/train-labels-idx1-ubyte.gz\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 28881/28881 [00:00<00:00, 57519322.80it/s]\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Extracting dataset/MNIST/raw/train-labels-idx1-ubyte.gz to dataset/MNIST/raw\n",
+            "\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to dataset/MNIST/raw/t10k-images-idx3-ubyte.gz\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 1648877/1648877 [00:00<00:00, 113770668.50it/s]"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Extracting dataset/MNIST/raw/t10k-images-idx3-ubyte.gz to dataset/MNIST/raw\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
+            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to dataset/MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 4542/4542 [00:00<00:00, 15350949.85it/s]"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Extracting dataset/MNIST/raw/t10k-labels-idx1-ubyte.gz to dataset/MNIST/raw\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\n"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/MNIST_VAE.ipynb
+++ b/MNIST_VAE.ipynb
@@ -4,7 +4,8 @@
   "metadata": {
     "colab": {
       "provenance": [],
-      "authorship_tag": "ABX9TyN7EUPcnax86HEhaVzfv6H5",
+      "gpuType": "V100",
+      "authorship_tag": "ABX9TyNFv7cc7urUaP8u9gPrfY3s",
       "include_colab_link": true
     },
     "kernelspec": {
@@ -13,7 +14,8 @@
     },
     "language_info": {
       "name": "python"
-    }
+    },
+    "accelerator": "GPU"
   },
   "cells": [
     {
@@ -30,64 +32,187 @@
       "cell_type": "code",
       "source": [
         "import torch\n",
-        "from torch import nn\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "import torch.optim as optim\n",
+        "from torchvision import datasets, transforms\n",
+        "from torch.autograd import Variable\n",
+        "from torchvision.utils import save_image\n",
         "\n",
+        "class VAE(nn.Module):\n",
+        "    def __init__(self, x_dim, h_dim1, h_dim2, z_dim):\n",
+        "        super(VAE, self).__init__()\n",
         "\n",
-        "class VariationalAutoEncoder(nn.Module):\n",
-        "    def __init__(self, input_dim, h_dim=200, z_dim=20):\n",
-        "        super().__init__()\n",
-        "        # encoder\n",
-        "        self.img_2hid = nn.Linear(input_dim, h_dim)\n",
-        "        self.hid_2mu = nn.Linear(h_dim, z_dim)\n",
-        "        self.hid_2sigma = nn.Linear(h_dim, z_dim)\n",
+        "        # encoder part\n",
+        "        self.fc1 = nn.Linear(x_dim, h_dim1)\n",
+        "        self.fc2 = nn.Linear(h_dim1, h_dim2)\n",
+        "        self.fc31 = nn.Linear(h_dim2, z_dim)\n",
+        "        self.fc32 = nn.Linear(h_dim2, z_dim)\n",
+        "        # decoder part\n",
+        "        self.fc4 = nn.Linear(z_dim, h_dim2)\n",
+        "        self.fc5 = nn.Linear(h_dim2, h_dim1)\n",
+        "        self.fc6 = nn.Linear(h_dim1, x_dim)\n",
         "\n",
-        "        # decoder\n",
-        "        self.z_2hid = nn.Linear(z_dim, h_dim)\n",
-        "        self.hid_2img = nn.Linear(h_dim, input_dim)\n",
+        "    def encoder(self, x):\n",
+        "        h = F.relu(self.fc1(x))\n",
+        "        h = F.relu(self.fc2(h))\n",
+        "        return self.fc31(h), self.fc32(h) # mu, log_var\n",
         "\n",
-        "        self.relu = nn.ReLU()\n",
+        "    def sampling(self, mu, log_var):\n",
+        "        std = torch.exp(0.5*log_var)\n",
+        "        eps = torch.randn_like(std)\n",
+        "        return eps.mul(std).add_(mu) # return z sample\n",
         "\n",
-        "    def encode(self, x):\n",
-        "        h = self.relu(self.img_2hid(x))\n",
-        "        mu, sigma = self.hid_2mu(h), self.hid_2sigma(h)\n",
-        "        return mu, sigma\n",
-        "\n",
-        "    def decode(self, z):\n",
-        "        h = self.relu(self.z_2hid(z))\n",
-        "        return torch.sigmoid(self.hid_2img(h))\n",
+        "    def decoder(self, z):\n",
+        "        h = F.relu(self.fc4(z))\n",
+        "        h = F.relu(self.fc5(h))\n",
+        "        return F.sigmoid(self.fc6(h))\n",
         "\n",
         "    def forward(self, x):\n",
-        "        mu, sigma = self.encode(x)\n",
-        "        epsilon = torch.randn_like(sigma)\n",
-        "        z_new = mu + sigma*epsilon\n",
-        "        x_reconstructed = self.decode(z_new)\n",
-        "        return x_reconstructed, mu, sigma\n",
+        "        mu, log_var = self.encoder(x.view(-1, 784))\n",
+        "        z = self.sampling(mu, log_var)\n",
+        "        return self.decoder(z), mu, log_var\n",
         "\n",
+        "# build model\n",
+        "vae = VAE(x_dim=784, h_dim1= 512, h_dim2=256, z_dim=2)\n",
+        "if torch.cuda.is_available():\n",
+        "    vae.cuda()"
+      ],
+      "metadata": {
+        "id": "aUrAwRsuczhT"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "optimizer = optim.Adam(vae.parameters())\n",
+        "# return reconstruction error + KL divergence losses\n",
+        "def loss_function(recon_x, x, mu, log_var):\n",
+        "    BCE = F.binary_cross_entropy(recon_x, x.view(-1, 784), reduction='sum')\n",
+        "    KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp())\n",
+        "    return BCE + KLD"
+      ],
+      "metadata": {
+        "id": "wjm2uRBuCwRw"
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def train(epoch):\n",
+        "    vae.train()\n",
+        "    train_loss = 0\n",
+        "    for batch_idx, (data, _) in enumerate(train_loader):\n",
+        "        data = data.cuda()\n",
+        "        optimizer.zero_grad()\n",
         "\n",
-        "if __name__ == \"__main__\":\n",
-        "    x = torch.randn(4, 28*28)\n",
-        "    vae = VariationalAutoEncoder(input_dim=784)\n",
-        "    x_reconstructed, mu, sigma = vae(x)\n",
-        "    print(x_reconstructed.shape)\n",
-        "    print(mu.shape)\n",
-        "    print(sigma.shape)"
+        "        recon_batch, mu, log_var = vae(data)\n",
+        "        loss = loss_function(recon_batch, data, mu, log_var)\n",
+        "\n",
+        "        loss.backward()\n",
+        "        train_loss += loss.item()\n",
+        "        optimizer.step()\n",
+        "\n",
+        "        if batch_idx % 100 == 0:\n",
+        "            print('Train Epoch: {} [{}/{} ({:.0f}%)]\\tLoss: {:.6f}'.format(\n",
+        "                epoch, batch_idx * len(data), len(train_loader.dataset),\n",
+        "                100. * batch_idx / len(train_loader), loss.item() / len(data)))\n",
+        "    print('====> Epoch: {} Average loss: {:.4f}'.format(epoch, train_loss / len(train_loader.dataset)))"
+      ],
+      "metadata": {
+        "id": "uEW-KyH9CyRl"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def test():\n",
+        "    vae.eval()\n",
+        "    test_loss= 0\n",
+        "    with torch.no_grad():\n",
+        "        for data, _ in test_loader:\n",
+        "            data = data.cuda()\n",
+        "            recon, mu, log_var = vae(data)\n",
+        "\n",
+        "            # sum up batch loss\n",
+        "            test_loss += loss_function(recon, data, mu, log_var).item()\n",
+        "\n",
+        "    test_loss /= len(test_loader.dataset)\n",
+        "    print('====> Test set loss: {:.4f}'.format(test_loss))"
+      ],
+      "metadata": {
+        "id": "KzRp7-ejC3-c"
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "bs = 100\n",
+        "# MNIST Dataset\n",
+        "train_dataset = datasets.MNIST(root='./mnist_data/', train=True, transform=transforms.ToTensor(), download=True)\n",
+        "test_dataset = datasets.MNIST(root='./mnist_data/', train=False, transform=transforms.ToTensor(), download=False)\n",
+        "\n",
+        "# Data Loader (Input Pipeline)\n",
+        "train_loader = torch.utils.data.DataLoader(dataset=train_dataset, batch_size=bs, shuffle=True)\n",
+        "test_loader = torch.utils.data.DataLoader(dataset=test_dataset, batch_size=bs, shuffle=False)\n",
+        "\n",
+        "for epoch in range(1, 5):\n",
+        "    train(epoch)\n",
+        "    test()"
       ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "aUrAwRsuczhT",
-        "outputId": "a7bb51b2-7966-4617-dec5-98c3d0c3a91e"
+        "id": "ZZw1jZc6C5ej",
+        "outputId": "6313b1c8-1b6d-4ab3-f6aa-a96b893bcbe4"
       },
-      "execution_count": 1,
+      "execution_count": 14,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "torch.Size([4, 784])\n",
-            "torch.Size([4, 20])\n",
-            "torch.Size([4, 20])\n"
+            "Train Epoch: 1 [0/60000 (0%)]\tLoss: 132.513184\n",
+            "Train Epoch: 1 [10000/60000 (17%)]\tLoss: 145.551279\n",
+            "Train Epoch: 1 [20000/60000 (33%)]\tLoss: 143.799668\n",
+            "Train Epoch: 1 [30000/60000 (50%)]\tLoss: 144.562568\n",
+            "Train Epoch: 1 [40000/60000 (67%)]\tLoss: 133.205791\n",
+            "Train Epoch: 1 [50000/60000 (83%)]\tLoss: 134.887256\n",
+            "====> Epoch: 1 Average loss: 141.1480\n",
+            "====> Test set loss: 142.4788\n",
+            "Train Epoch: 2 [0/60000 (0%)]\tLoss: 141.568389\n",
+            "Train Epoch: 2 [10000/60000 (17%)]\tLoss: 131.814111\n",
+            "Train Epoch: 2 [20000/60000 (33%)]\tLoss: 131.404941\n",
+            "Train Epoch: 2 [30000/60000 (50%)]\tLoss: 135.604023\n",
+            "Train Epoch: 2 [40000/60000 (67%)]\tLoss: 138.471006\n",
+            "Train Epoch: 2 [50000/60000 (83%)]\tLoss: 143.901602\n",
+            "====> Epoch: 2 Average loss: 140.6990\n",
+            "====> Test set loss: 141.7708\n",
+            "Train Epoch: 3 [0/60000 (0%)]\tLoss: 151.875791\n",
+            "Train Epoch: 3 [10000/60000 (17%)]\tLoss: 143.209922\n",
+            "Train Epoch: 3 [20000/60000 (33%)]\tLoss: 136.077578\n",
+            "Train Epoch: 3 [30000/60000 (50%)]\tLoss: 137.678623\n",
+            "Train Epoch: 3 [40000/60000 (67%)]\tLoss: 132.750098\n",
+            "Train Epoch: 3 [50000/60000 (83%)]\tLoss: 138.461543\n",
+            "====> Epoch: 3 Average loss: 140.3149\n",
+            "====> Test set loss: 141.3095\n",
+            "Train Epoch: 4 [0/60000 (0%)]\tLoss: 141.891445\n",
+            "Train Epoch: 4 [10000/60000 (17%)]\tLoss: 136.609824\n",
+            "Train Epoch: 4 [20000/60000 (33%)]\tLoss: 138.829805\n",
+            "Train Epoch: 4 [30000/60000 (50%)]\tLoss: 139.648555\n",
+            "Train Epoch: 4 [40000/60000 (67%)]\tLoss: 140.374023\n",
+            "Train Epoch: 4 [50000/60000 (83%)]\tLoss: 132.872568\n",
+            "====> Epoch: 4 Average loss: 140.0112\n",
+            "====> Test set loss: 141.5408\n"
           ]
         }
       ]
@@ -95,171 +220,17 @@
     {
       "cell_type": "code",
       "source": [
-        "import torch\n",
-        "import torchvision.datasets as datasets  # Standard datasets\n",
-        "from tqdm import tqdm\n",
-        "from torch import nn, optim\n",
-        "from torchvision import transforms\n",
-        "from torchvision.utils import save_image\n",
-        "from torch.utils.data import DataLoader\n",
+        "with torch.no_grad():\n",
+        "    z = torch.randn(64, 2).cuda()\n",
+        "    sample = vae.decoder(z).cuda()\n",
         "\n",
-        "# Configuration\n",
-        "DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-        "INPUT_DIM = 784\n",
-        "H_DIM = 200\n",
-        "Z_DIM = 20\n",
-        "NUM_EPOCHS = 50\n",
-        "BATCH_SIZE = 32\n",
-        "LR_RATE = 3e-4  # Karpathy constant\n",
-        "\n",
-        "# Dataset Loading\n",
-        "dataset = datasets.MNIST(root=\"dataset/\", train=True, transform=transforms.ToTensor(), download=True)\n",
-        "train_loader = DataLoader(dataset=dataset, batch_size=BATCH_SIZE, shuffle=True)\n",
-        "model = VariationalAutoEncoder(INPUT_DIM, H_DIM, Z_DIM).to(DEVICE)\n",
-        "optimizer = optim.Adam(model.parameters(), lr=LR_RATE)\n",
-        "loss_fn = nn.BCELoss(reduction=\"sum\")\n",
-        "\n",
-        "\n",
-        "def inference(digit, num_examples=1):\n",
-        "    \"\"\"\n",
-        "    Generates (num_examples) of a particular digit.\n",
-        "    Specifically we extract an example of each digit,\n",
-        "    then after we have the mu, sigma representation for\n",
-        "    each digit we can sample from that.\n",
-        "\n",
-        "    After we sample we can run the decoder part of the VAE\n",
-        "    and generate examples.\n",
-        "    \"\"\"\n",
-        "    images = []\n",
-        "    idx = 0\n",
-        "    for x, y in dataset:\n",
-        "        if y == idx:\n",
-        "            images.append(x)\n",
-        "            idx += 1\n",
-        "        if idx == 10:\n",
-        "            break\n",
-        "\n",
-        "    encodings_digit = []\n",
-        "    for d in range(10):\n",
-        "        with torch.no_grad():\n",
-        "            mu, sigma = model.encode(images[d].view(1, 784))\n",
-        "        encodings_digit.append((mu, sigma))\n",
-        "\n",
-        "    mu, sigma = encodings_digit[digit]\n",
-        "    for example in range(num_examples):\n",
-        "        epsilon = torch.randn_like(sigma)\n",
-        "        z = mu + sigma * epsilon\n",
-        "        out = model.decode(z)\n",
-        "        out = out.view(-1, 1, 28, 28)\n",
-        "        save_image(out, f\"generated_{digit}_ex{example}.png\")\n",
-        "\n",
-        "for idx in range(10):\n",
-        "    inference(idx, num_examples=100)"
+        "    save_image(sample.view(64, 1, 28, 28), 'a.png')"
       ],
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "11Vv5N75g1ND",
-        "outputId": "3f169817-a6d4-473a-8b27-73be0ebc7af2"
+        "id": "11Vv5N75g1ND"
       },
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to dataset/MNIST/raw/train-images-idx3-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "100%|██████████| 9912422/9912422 [00:00<00:00, 128956920.73it/s]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting dataset/MNIST/raw/train-images-idx3-ubyte.gz to dataset/MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to dataset/MNIST/raw/train-labels-idx1-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "100%|██████████| 28881/28881 [00:00<00:00, 57519322.80it/s]\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting dataset/MNIST/raw/train-labels-idx1-ubyte.gz to dataset/MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to dataset/MNIST/raw/t10k-images-idx3-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "100%|██████████| 1648877/1648877 [00:00<00:00, 113770668.50it/s]"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting dataset/MNIST/raw/t10k-images-idx3-ubyte.gz to dataset/MNIST/raw\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to dataset/MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "100%|██████████| 4542/4542 [00:00<00:00, 15350949.85it/s]"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting dataset/MNIST/raw/t10k-labels-idx1-ubyte.gz to dataset/MNIST/raw\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\n"
-          ]
-        }
-      ]
+      "execution_count": 20,
+      "outputs": []
     }
   ]
 }

--- a/detection/backbone.py
+++ b/detection/backbone.py
@@ -8,9 +8,8 @@ from typing import Dict
 import itertools
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath, trunc_normal_
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
 from timm.models.registry import register_model
-from timm.models.layers.helpers import to_2tuple
 
 try:
     from mmdet.models.builder import BACKBONES as det_BACKBONES

--- a/detection/backbonev2.py
+++ b/detection/backbonev2.py
@@ -8,9 +8,8 @@ from typing import Dict
 import itertools
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath, trunc_normal_
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
 from timm.models.registry import register_model
-from timm.models.layers.helpers import to_2tuple
 
 try:
     from mmdet.models.builder import BACKBONES as det_BACKBONES

--- a/models/efficientformer.py
+++ b/models/efficientformer.py
@@ -10,9 +10,8 @@ from typing import Dict
 import itertools
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath, trunc_normal_
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
 from timm.models.registry import register_model
-from timm.models.layers.helpers import to_2tuple
 
 EfficientFormer_width = {
     'l1': [48, 96, 224, 448],

--- a/models/efficientformer_v2.py
+++ b/models/efficientformer_v2.py
@@ -11,9 +11,8 @@ from typing import Dict
 import itertools
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath, trunc_normal_
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
 from timm.models.registry import register_model
-from timm.models.layers.helpers import to_2tuple
 
 EfficientFormer_width = {
     'L': [40, 80, 192, 384],  # 26m 83.3% 6attn

--- a/segmentation/backbone.py
+++ b/segmentation/backbone.py
@@ -11,9 +11,8 @@ from typing import Dict
 import itertools
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath, trunc_normal_
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
 from timm.models.registry import register_model
-from timm.models.layers.helpers import to_2tuple
 
 try:
     from mmseg.models.builder import BACKBONES as seg_BACKBONES

--- a/segmentation/backbonev2.py
+++ b/segmentation/backbonev2.py
@@ -8,9 +8,8 @@ from typing import Dict
 import itertools
 
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
-from timm.models.layers import DropPath, trunc_normal_
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
 from timm.models.registry import register_model
-from timm.models.layers.helpers import to_2tuple
 
 try:
     from mmseg.models.builder import BACKBONES as seg_BACKBONES


### PR DESCRIPTION
According to updates to the timm module after Oct 10, 2022 (available in version >= 0.9):
<img width="774" alt="image" src="https://github.com/snap-research/EfficientFormer/assets/58625220/93fc640c-b06d-47a0-8035-54c153c52d46">
